### PR TITLE
feat: 설문추천 이력 조회 API (SCENTLY-119)

### DIFF
--- a/apps/recommendation/serializers/recommendation_history_serializer.py
+++ b/apps/recommendation/serializers/recommendation_history_serializer.py
@@ -1,0 +1,110 @@
+from rest_framework import serializers
+
+from apps.product.models import Perfume
+from apps.recommendation.models import Recommendation, RecommendationHistory
+
+
+# 추천된 향수 정보
+class RecommendedPerfumeSerializer(serializers.Serializer):
+    perfume_id = serializers.IntegerField(source="perfume.id")
+    perfume_name = serializers.CharField(source="perfume.name")
+    brand = serializers.CharField(source="perfume.brand")
+    similarity_score = serializers.DecimalField(max_digits=5, decimal_places=4, allow_null=True)
+
+
+# 목록용 추천된 향수 간단 정보
+class RecommendedPerfumeBriefSerializer(serializers.Serializer):
+    perfume_id = serializers.IntegerField(source="perfume.id")
+    perfume_name = serializers.CharField(source="perfume.name")
+    brand = serializers.CharField(source="perfume.brand")
+
+
+# 추천 이력 목록 시리얼라이저
+class RecommendationHistoryListSerializer(serializers.ModelSerializer):
+    history_id = serializers.IntegerField(source="id")
+    recommended_at = serializers.DateTimeField(source="created_at")
+    recommendation_type = serializers.CharField(source="type")
+    perfume_count = serializers.SerializerMethodField()
+    first_perfume = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Recommendation
+        fields = ["history_id", "recommended_at", "recommendation_type", "perfume_count", "first_perfume"]
+
+    def get_perfume_count(self, obj):
+        return obj.histories.count()
+
+    def get_first_perfume(self, obj):
+        first_history = obj.histories.select_related("perfume").first()
+        if first_history:
+            return RecommendedPerfumeBriefSerializer(first_history).data
+        return None
+
+
+# 추천 이력 상세 시리얼라이저
+class RecommendationHistoryDetailSerializer(serializers.ModelSerializer):
+    history_id = serializers.IntegerField(source="id")
+    recommended_at = serializers.DateTimeField(source="created_at")
+    recommendation_type = serializers.CharField(source="type")
+    condition = serializers.SerializerMethodField()
+    recommended_perfumes = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Recommendation
+        fields = ["history_id", "recommended_at", "recommendation_type", "condition", "recommended_perfumes"]
+
+    # context 필드에 JSON 형태로 저장된 설문 데이터 파싱
+    def get_condition(self, obj):
+        try:
+            import json
+
+            if obj.context:
+                return json.loads(obj.context)
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+        return {"mood": "", "intensity": "", "usage": "", "keyword": ""}
+
+    def get_recommended_perfumes(self, obj):
+        histories = obj.histories.select_related("perfume").order_by("created_at")
+        return RecommendedPerfumeSerializer(histories, many=True).data
+
+
+# 추천 이력 생성용 시리얼라이저
+class RecommendationHistoryCreateSerializer(serializers.Serializer):
+    survey_data = serializers.JSONField(help_text="설문 응답 데이터")
+    perfume_ids = serializers.ListField(child=serializers.IntegerField(), help_text="추천된 향수 ID 리스트")
+    scores = serializers.ListField(
+        child=serializers.DecimalField(max_digits=5, decimal_places=4),
+        required=False,
+        help_text="추천 점수 리스트 (선택사항)",
+    )
+    recommendation_type = serializers.ChoiceField(
+        choices=Recommendation.Type.choices, default=Recommendation.Type.SURVEY, help_text="추천 유형"
+    )
+
+    def validate(self, data):
+        perfume_ids = data["perfume_ids"]
+        scores = data.get("scores", [])
+
+        if scores and len(scores) != len(perfume_ids):
+            raise serializers.ValidationError("점수 리스트 길이가 향수 ID 리스트와 일치하지 않습니다.")
+
+        existing_perfume_ids = set(Perfume.objects.filter(id__in=perfume_ids).values_list("id", flat=True))
+        invalid_ids = set(perfume_ids) - existing_perfume_ids
+        if invalid_ids:
+            raise serializers.ValidationError(f"존재하지 않는 향수 ID: {list(invalid_ids)}")
+
+        return data
+
+
+# 단일 추천 이력 항목 시리얼라이저 (RecommendationHistory 모델용)
+class RecommendationHistoryItemSerializer(serializers.ModelSerializer):
+    perfume_id = serializers.IntegerField(source="perfume.id")
+    perfume_name = serializers.CharField(source="perfume.name")
+    brand = serializers.CharField(source="perfume.brand")
+    recommendation_id = serializers.IntegerField(source="recommendation.id")
+
+    class Meta:
+        model = RecommendationHistory
+        fields = ["id", "perfume_id", "perfume_name", "brand", "similarity_score", "recommendation_id", "created_at"]

--- a/apps/recommendation/serializers/recommendation_history_serializer.py
+++ b/apps/recommendation/serializers/recommendation_history_serializer.py
@@ -1,3 +1,5 @@
+import json
+
 from rest_framework import serializers
 
 from apps.product.models import Perfume
@@ -24,18 +26,15 @@ class RecommendationHistoryListSerializer(serializers.ModelSerializer):
     history_id = serializers.IntegerField(source="id")
     recommended_at = serializers.DateTimeField(source="created_at")
     recommendation_type = serializers.CharField(source="type")
-    perfume_count = serializers.SerializerMethodField()
+    perfume_count = serializers.IntegerField()
     first_perfume = serializers.SerializerMethodField()
 
     class Meta:
         model = Recommendation
         fields = ["history_id", "recommended_at", "recommendation_type", "perfume_count", "first_perfume"]
 
-    def get_perfume_count(self, obj):
-        return obj.histories.count()
-
     def get_first_perfume(self, obj):
-        first_history = obj.histories.select_related("perfume").first()
+        first_history = obj.histories.all()[0] if obj.histories.all() else None
         if first_history:
             return RecommendedPerfumeBriefSerializer(first_history).data
         return None
@@ -56,7 +55,6 @@ class RecommendationHistoryDetailSerializer(serializers.ModelSerializer):
     # context 필드에 JSON 형태로 저장된 설문 데이터 파싱
     def get_condition(self, obj):
         try:
-            import json
 
             if obj.context:
                 return json.loads(obj.context)

--- a/apps/recommendation/serializers/survey_recommendation_serializer.py
+++ b/apps/recommendation/serializers/survey_recommendation_serializer.py
@@ -44,3 +44,4 @@ class PerfumeBriefSerializer(serializers.Serializer):
     intensity = serializers.ChoiceField(choices=Perfume.IntensityChoices.choices, allow_null=True, required=False)
     main_accords = serializers.ListField(child=serializers.CharField(max_length=50), allow_empty=True)
     score = serializers.FloatField(min_value=0.0, max_value=1.0, help_text="임베딩 코사인 유사도 점수 (0.0 ~ 1.0)")
+    history_id = serializers.IntegerField(required=False)

--- a/apps/recommendation/tests/test_recommendation_history.py
+++ b/apps/recommendation/tests/test_recommendation_history.py
@@ -152,7 +152,7 @@ def multiple_recommendations(authenticated_user, sample_perfumes):
 def test_recommendation_history_list(api_client, authenticated_user, recommendation_history):
     api_client.force_authenticate(user=authenticated_user)
 
-    url = reverse("recommendation-history")
+    url = reverse("survey-recommendation-history")
     response = api_client.get(url)
 
     assert response.status_code == 200
@@ -184,7 +184,7 @@ def test_recommendation_history_list_multiple(api_client, authenticated_user, mu
     api_client.force_authenticate(user=authenticated_user)
     rec1, rec2 = multiple_recommendations
 
-    url = reverse("recommendation-history")
+    url = reverse("survey-recommendation-history")
     response = api_client.get(url)
 
     assert response.status_code == 200
@@ -264,7 +264,7 @@ def test_recommendation_history_detail_other_user(api_client, other_user, recomm
 def test_recommendation_history_empty_list(api_client, authenticated_user):
     api_client.force_authenticate(user=authenticated_user)
 
-    url = reverse("recommendation-history")
+    url = reverse("survey-recommendation-history")
     response = api_client.get(url)
 
     assert response.status_code == 200
@@ -278,7 +278,7 @@ def test_recommendation_history_empty_list(api_client, authenticated_user):
 @pytest.mark.django_db
 def test_recommendation_history_unauthenticated(api_client, recommendation_history):
     # 목록 조회
-    url = reverse("recommendation-history")
+    url = reverse("survey-recommendation-history")
     response = api_client.get(url)
     assert response.status_code == 401
 
@@ -350,7 +350,7 @@ def test_recommendation_history_performance(api_client, authenticated_user, samp
     with override_settings(DEBUG=True):
         connection.queries_log.clear()
 
-        url = reverse("recommendation-history")
+        url = reverse("survey-recommendation-history")
         response = api_client.get(url)
 
         # 쿼리 개수 확인 (N+1 문제가 해결되었다면 적은 수의 쿼리만 실행되어야 함)

--- a/apps/recommendation/tests/test_recommendation_history.py
+++ b/apps/recommendation/tests/test_recommendation_history.py
@@ -159,36 +159,23 @@ def test_recommendation_history_list(api_client, authenticated_user, recommendat
     data = response.json()
 
     assert "results" in data
+    assert "count" in data
     results = data["results"]
     assert len(results) == 1
-
+    assert data["count"] == 1
     history_item = results[0]
 
-    # 실제 응답 필드에 맞게 검증 수정
-    assert "id" in history_item
-    assert "type" in history_item
-    assert "created_at" in history_item
-    assert "histories" in history_item
+    required_fields = ["history_id", "recommended_at", "recommendation_type", "perfume_count", "first_perfume"]
+    for field in required_fields:
+        assert field in history_item, f"Missing field: {field}"
 
-    # 기본 정보 검증
-    assert history_item["id"] == recommendation_history.id
-    assert history_item["type"] == "survey"
+    assert history_item["history_id"] == recommendation_history.id
+    assert history_item["perfume_count"] == 2
+    assert history_item["recommendation_type"] == "survey"
 
-    # 추천된 향수들 검증 (histories 필드)
-    histories = history_item["histories"]
-    assert len(histories) == 2  # 우리가 생성한 향수 2개
-
-    # 첫 번째 향수 정보 검증
-    first_history = histories[0]
-    assert "perfume" in first_history
-    perfume = first_history["perfume"]
-    assert "name" in perfume
-    assert "brand" in perfume
-
-    # 향수 이름 확인
-    perfume_names = [h["perfume"]["name"] for h in histories]
-    assert "Romantic Musk" in perfume_names
-    assert "Blush Bloom" in perfume_names
+    first_perfume = history_item["first_perfume"]
+    assert first_perfume["perfume_name"] in ["Romantic Musk", "Blush Bloom"]
+    assert first_perfume["brand"] in ["Fragrance House", "Elegant Scent"]
 
 
 # 여러 추천 이력 목록 조회 테스트
@@ -206,16 +193,13 @@ def test_recommendation_history_list_multiple(api_client, authenticated_user, mu
     assert "results" in data
     results = data["results"]
     assert len(results) == 2
-
-    # 실제 필드에 맞게 검증
-    result_ids = [item["id"] for item in results]
-    assert rec1.id in result_ids
-    assert rec2.id in result_ids
+    assert data["count"] == 2
+    assert results[0]["history_id"] == rec2.id
+    assert results[1]["history_id"] == rec1.id
 
     # 타입 검증
-    result_types = [item["type"] for item in results]
-    assert "survey" in result_types
-    assert "ai" in result_types
+    assert results[0]["recommendation_type"] == "ai"
+    assert results[1]["recommendation_type"] == "survey"
 
 
 # 추천 이력 상세 조회 테스트
@@ -231,7 +215,7 @@ def test_recommendation_history_detail(api_client, authenticated_user, recommend
 
     required_fields = ["history_id", "recommended_at", "recommendation_type", "condition", "recommended_perfumes"]
     for field in required_fields:
-        assert field in data, f"Missing field: {field}. Available fields: {list(data.keys())}"
+        assert field in data, f"Missing field: {field}"
 
     assert data["history_id"] == recommendation_history.id
     assert data["recommendation_type"] == "survey"
@@ -287,6 +271,7 @@ def test_recommendation_history_empty_list(api_client, authenticated_user):
     data = response.json()
     assert "results" in data
     assert len(data["results"]) == 0
+    assert data["count"] == 0
 
 
 # 인증되지 않은 사용자의 접근 시 401 - 인증하지 않은 상태로 요청
@@ -332,3 +317,50 @@ def test_recommendation_context_parsing_fallback(api_client, authenticated_user,
     # fallback 조건 검증 (JSON 파싱 실패시 기본값)
     condition = data["condition"]
     assert condition == {"mood": "", "intensity": "", "usage": "", "keyword": ""}
+
+
+# N+1 쿼리 문제가 해결되었는지 성능 테스트
+@pytest.mark.django_db
+def test_recommendation_history_performance(api_client, authenticated_user, sample_perfumes):
+    perfume1, perfume2 = sample_perfumes
+
+    # 여러 추천 생성 (성능 테스트용)
+    for i in range(5):
+        recommendation = Recommendation.objects.create(
+            user=authenticated_user,
+            type=Recommendation.Type.SURVEY,
+            description=f"테스트 추천 {i+1}",
+            context=json.dumps({"test": f"data_{i}"}),
+        )
+
+        # 각 추천마다 2개씩 향수 추가
+        RecommendationHistory.objects.create(
+            recommendation=recommendation, perfume=perfume1, similarity_score=0.8 + i * 0.01
+        )
+        RecommendationHistory.objects.create(
+            recommendation=recommendation, perfume=perfume2, similarity_score=0.7 + i * 0.01
+        )
+
+    api_client.force_authenticate(user=authenticated_user)
+
+    # 쿼리 개수 측정
+    from django.db import connection
+    from django.test.utils import override_settings
+
+    with override_settings(DEBUG=True):
+        connection.queries_log.clear()
+
+        url = reverse("recommendation-history")
+        response = api_client.get(url)
+
+        # 쿼리 개수 확인 (N+1 문제가 해결되었다면 적은 수의 쿼리만 실행되어야 함)
+        query_count = len(connection.queries)
+        print(f"실행된 쿼리 개수: {query_count}")
+
+        assert query_count <= 5, f"너무 많은 쿼리 실행됨: {query_count}개"
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "results" in data
+    assert data["count"] == 5
+    assert len(data["results"]) == 5

--- a/apps/recommendation/tests/test_recommendation_history.py
+++ b/apps/recommendation/tests/test_recommendation_history.py
@@ -1,0 +1,334 @@
+import json
+from datetime import date, datetime, timezone
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from apps.product.models import MainAccord, Note, Perfume, Product
+from apps.recommendation.models import Recommendation, RecommendationHistory
+
+User = get_user_model()
+
+
+@pytest.fixture
+def authenticated_user(db):
+    return User.objects.create_user(
+        email="test@example.com",
+        password="testpass123",
+        name="Test User",
+        nickname="testuser",
+        gender="MALE",
+        birth_date=date(1995, 5, 15),
+        phone_number="010-1234-5678",
+        is_active=True,
+    )
+
+
+@pytest.fixture
+def other_user(db):
+    return User.objects.create_user(
+        email="other@example.com",
+        password="testpass123",
+        name="Other User",
+        nickname="otheruser",
+        gender="FEMALE",
+        birth_date=date(1990, 3, 20),
+        phone_number="010-9876-5432",
+        is_active=True,
+    )
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def sample_perfumes(db):
+    # 노트 생성
+    rose_note = Note.objects.create(name="rose", type="top")
+    musk_note = Note.objects.create(name="musk", type="base")
+    citrus_note = Note.objects.create(name="citrus", type="top")
+
+    # 어코드 생성
+    romantic_accord = MainAccord.objects.create(name="romantic")
+    fresh_accord = MainAccord.objects.create(name="fresh")
+
+    perfume1 = Perfume.objects.create(
+        name="Romantic Musk",
+        brand="Fragrance House",
+        release_year=2023,
+        intensity="eau_de_parfum",
+        embedding=[0.8] * 512,
+    )
+    perfume1.top_notes.add(rose_note)
+    perfume1.base_notes.add(musk_note)
+    perfume1.main_accords.add(romantic_accord)
+
+    Product.objects.create(
+        perfume=perfume1,
+        volume_ml=50,
+        name="Romantic Musk 50ml",
+        description="로맨틱한 향수",
+        category="Special",
+        price=150000,
+        stock=3,
+    )
+
+    perfume2 = Perfume.objects.create(
+        name="Blush Bloom", brand="Elegant Scent", release_year=2023, intensity="eau_de_toilette", embedding=[0.7] * 512
+    )
+    perfume2.top_notes.add(rose_note)
+    perfume2.main_accords.add(romantic_accord)
+
+    Product.objects.create(
+        perfume=perfume2,
+        volume_ml=30,
+        name="Blush Bloom 30ml",
+        description="우아한 향수",
+        category="Daily",
+        price=89000,
+        stock=5,
+    )
+
+    return perfume1, perfume2
+
+
+@pytest.fixture
+def recommendation_history(authenticated_user, sample_perfumes):
+    perfume1, perfume2 = sample_perfumes
+
+    recommendation = Recommendation.objects.create(
+        user=authenticated_user,
+        type=Recommendation.Type.SURVEY,
+        description="설문 기반 향수 추천",
+        reason="사용자 설문 응답을 바탕으로 한 개인화 추천",
+        context=json.dumps(
+            {"mood": "로맨틱한", "intensity": "적당한 향이 좋아요", "usage": "데일리용", "keyword": "사랑스러운"},
+            ensure_ascii=False,
+        ),
+    )
+
+    history1 = RecommendationHistory.objects.create(
+        recommendation=recommendation, perfume=perfume1, similarity_score=0.89
+    )
+
+    history2 = RecommendationHistory.objects.create(
+        recommendation=recommendation, perfume=perfume2, similarity_score=0.76
+    )
+
+    return recommendation
+
+
+@pytest.fixture
+def multiple_recommendations(authenticated_user, sample_perfumes):
+    perfume1, perfume2 = sample_perfumes
+
+    # 첫 번째 추천 세션
+    rec1 = Recommendation.objects.create(
+        user=authenticated_user,
+        type=Recommendation.Type.SURVEY,
+        description="첫 번째 추천",
+        context=json.dumps({"mood": "상쾌한", "keyword": "활기찬"}),
+    )
+    RecommendationHistory.objects.create(recommendation=rec1, perfume=perfume1, similarity_score=0.85)
+
+    # 두 번째 추천 세션
+    rec2 = Recommendation.objects.create(
+        user=authenticated_user,
+        type=Recommendation.Type.AI,
+        description="AI 기반 추천",
+        context=json.dumps({"preferences": "복합적"}),
+    )
+    RecommendationHistory.objects.create(recommendation=rec2, perfume=perfume2, similarity_score=0.92)
+
+    return rec1, rec2
+
+
+# 추천 이력 목록 조회 테스트
+@pytest.mark.django_db
+def test_recommendation_history_list(api_client, authenticated_user, recommendation_history):
+    api_client.force_authenticate(user=authenticated_user)
+
+    url = reverse("recommendation-history")
+    response = api_client.get(url)
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert "results" in data
+    results = data["results"]
+    assert len(results) == 1
+
+    history_item = results[0]
+
+    # 실제 응답 필드에 맞게 검증 수정
+    assert "id" in history_item
+    assert "type" in history_item
+    assert "created_at" in history_item
+    assert "histories" in history_item
+
+    # 기본 정보 검증
+    assert history_item["id"] == recommendation_history.id
+    assert history_item["type"] == "survey"
+
+    # 추천된 향수들 검증 (histories 필드)
+    histories = history_item["histories"]
+    assert len(histories) == 2  # 우리가 생성한 향수 2개
+
+    # 첫 번째 향수 정보 검증
+    first_history = histories[0]
+    assert "perfume" in first_history
+    perfume = first_history["perfume"]
+    assert "name" in perfume
+    assert "brand" in perfume
+
+    # 향수 이름 확인
+    perfume_names = [h["perfume"]["name"] for h in histories]
+    assert "Romantic Musk" in perfume_names
+    assert "Blush Bloom" in perfume_names
+
+
+# 여러 추천 이력 목록 조회 테스트
+@pytest.mark.django_db
+def test_recommendation_history_list_multiple(api_client, authenticated_user, multiple_recommendations):
+    api_client.force_authenticate(user=authenticated_user)
+    rec1, rec2 = multiple_recommendations
+
+    url = reverse("recommendation-history")
+    response = api_client.get(url)
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert "results" in data
+    results = data["results"]
+    assert len(results) == 2
+
+    # 실제 필드에 맞게 검증
+    result_ids = [item["id"] for item in results]
+    assert rec1.id in result_ids
+    assert rec2.id in result_ids
+
+    # 타입 검증
+    result_types = [item["type"] for item in results]
+    assert "survey" in result_types
+    assert "ai" in result_types
+
+
+# 추천 이력 상세 조회 테스트
+@pytest.mark.django_db
+def test_recommendation_history_detail(api_client, authenticated_user, recommendation_history):
+    api_client.force_authenticate(user=authenticated_user)
+
+    url = reverse("recommendation-history-detail", kwargs={"history_id": recommendation_history.id})
+    response = api_client.get(url)
+
+    assert response.status_code == 200
+    data = response.json()
+
+    required_fields = ["history_id", "recommended_at", "recommendation_type", "condition", "recommended_perfumes"]
+    for field in required_fields:
+        assert field in data, f"Missing field: {field}. Available fields: {list(data.keys())}"
+
+    assert data["history_id"] == recommendation_history.id
+    assert data["recommendation_type"] == "survey"
+
+    # 조건 정보 검증 (context에서 파싱된 설문 데이터)
+    condition = data["condition"]
+    assert condition["mood"] == "로맨틱한"
+    assert condition["intensity"] == "적당한 향이 좋아요"
+    assert condition["usage"] == "데일리용"
+    assert condition["keyword"] == "사랑스러운"
+
+    # 추천 향수들 검증
+    recommended_perfumes = data["recommended_perfumes"]
+    assert len(recommended_perfumes) == 2
+
+    # 향수 정보 검증
+    perfume_names = [p["perfume_name"] for p in recommended_perfumes]
+    assert "Romantic Musk" in perfume_names
+    assert "Blush Bloom" in perfume_names
+
+
+# 존재하지 않는 이력 조회 시 404
+@pytest.mark.django_db
+def test_recommendation_history_detail_not_found(api_client, authenticated_user):
+    api_client.force_authenticate(user=authenticated_user)
+
+    url = reverse("recommendation-history-detail", kwargs={"history_id": 99999})
+    response = api_client.get(url)
+
+    assert response.status_code == 404
+
+
+# 다른 사용자의 이력 조회 시 404 (권한 없음)
+@pytest.mark.django_db
+def test_recommendation_history_detail_other_user(api_client, other_user, recommendation_history):
+    api_client.force_authenticate(user=other_user)
+
+    url = reverse("recommendation-history-detail", kwargs={"history_id": recommendation_history.id})
+    response = api_client.get(url)
+
+    assert response.status_code == 404
+
+
+# 추천 이력이 없는 경우 빈 목록 반환
+@pytest.mark.django_db
+def test_recommendation_history_empty_list(api_client, authenticated_user):
+    api_client.force_authenticate(user=authenticated_user)
+
+    url = reverse("recommendation-history")
+    response = api_client.get(url)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "results" in data
+    assert len(data["results"]) == 0
+
+
+# 인증되지 않은 사용자의 접근 시 401 - 인증하지 않은 상태로 요청
+@pytest.mark.django_db
+def test_recommendation_history_unauthenticated(api_client, recommendation_history):
+    # 목록 조회
+    url = reverse("recommendation-history")
+    response = api_client.get(url)
+    assert response.status_code == 401
+
+    # 상세 조회
+    url = reverse("recommendation-history-detail", kwargs={"history_id": recommendation_history.id})
+    response = api_client.get(url)
+    assert response.status_code == 401
+
+
+# context JSON 파싱 관련 테스트
+@pytest.mark.django_db
+def test_recommendation_context_parsing_fallback(api_client, authenticated_user, sample_perfumes):
+    perfume1, _ = sample_perfumes
+
+    # 잘못된 JSON context를 가진 추천 생성
+    recommendation = Recommendation.objects.create(
+        user=authenticated_user,
+        type=Recommendation.Type.SURVEY,
+        description="잘못된 컨텍스트 테스트",
+        context="invalid json string",  # 잘못된 JSON
+    )
+
+    RecommendationHistory.objects.create(recommendation=recommendation, perfume=perfume1, similarity_score=0.75)
+
+    api_client.force_authenticate(user=authenticated_user)
+
+    url = reverse("recommendation-history-detail", kwargs={"history_id": recommendation.id})
+    response = api_client.get(url)
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["history_id"] == recommendation.id
+    assert data["recommendation_type"] == "survey"
+
+    # fallback 조건 검증 (JSON 파싱 실패시 기본값)
+    condition = data["condition"]
+    assert condition == {"mood": "", "intensity": "", "usage": "", "keyword": ""}

--- a/apps/recommendation/tests/test_survey_recommendation.py
+++ b/apps/recommendation/tests/test_survey_recommendation.py
@@ -1,3 +1,4 @@
+import json
 from datetime import date
 
 import pytest
@@ -5,13 +6,12 @@ from django.contrib.auth import get_user_model
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
-import json
 
 from apps.product.models import MainAccord, Note, Perfume, Product
+from apps.recommendation.models import Recommendation, RecommendationHistory
 from apps.recommendation.views.survey_recommendation_view import (
     PerfumeRecommendationView,
 )
-from apps.recommendation.models import Recommendation, RecommendationHistory
 
 User = get_user_model()
 
@@ -305,6 +305,7 @@ def test_perfume_recommendation_response_structure(api_client, perfume_test_data
     valid_intensities = ["parfum", "eau_de_parfum", "eau_de_toilette", "eau_de_cologne", "eau_fraiche"]
     assert data["intensity"] in valid_intensities
 
+
 # 이력 저장 기능 테스트
 @pytest.mark.django_db
 def test_perfume_recommendation_saves_history(api_client, perfume_test_data, authenticated_user):
@@ -351,7 +352,7 @@ def test_perfume_recommendation_saves_history(api_client, perfume_test_data, aut
     assert history.similarity_score == data["score"]
 
 
-#이력 저장 실패해도 추천 결과는 정상 반환되는지 확인
+# 이력 저장 실패해도 추천 결과는 정상 반환되는지 확인
 @pytest.mark.django_db
 def test_perfume_recommendation_history_failure_still_returns_result(
     api_client, perfume_test_data, authenticated_user, mocker
@@ -389,7 +390,7 @@ def test_perfume_recommendation_history_failure_still_returns_result(
     mock_create_history.assert_called_once()
 
 
-#비인증 사용자는 이력이 저장되지 않음을 확인
+# 비인증 사용자는 이력이 저장되지 않음을 확인
 @pytest.mark.django_db
 def test_unauthenticated_user_no_history_saved(api_client, perfume_test_data):
     url = reverse("survey-recommendation")

--- a/apps/recommendation/tests/test_survey_recommendation.py
+++ b/apps/recommendation/tests/test_survey_recommendation.py
@@ -5,8 +5,13 @@ from django.contrib.auth import get_user_model
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
+import json
 
 from apps.product.models import MainAccord, Note, Perfume, Product
+from apps.recommendation.views.survey_recommendation_view import (
+    PerfumeRecommendationView,
+)
+from apps.recommendation.models import Recommendation, RecommendationHistory
 
 User = get_user_model()
 
@@ -289,6 +294,144 @@ def test_perfume_recommendation_response_structure(api_client, perfume_test_data
     for field in required_fields:
         assert field in data, f"Missing field: {field}"
 
+    assert isinstance(data["id"], int)
+    assert isinstance(data["name"], str)
+    assert isinstance(data["brand"], str)
+    assert isinstance(data["intensity"], str)
+    assert isinstance(data["main_accords"], list)
+    assert isinstance(data["score"], float)
+    assert 0.0 <= data["score"] <= 1.0
+
+    valid_intensities = ["parfum", "eau_de_parfum", "eau_de_toilette", "eau_de_cologne", "eau_fraiche"]
+    assert data["intensity"] in valid_intensities
+
+# 이력 저장 기능 테스트
+@pytest.mark.django_db
+def test_perfume_recommendation_saves_history(api_client, perfume_test_data, authenticated_user):
+    api_client.force_authenticate(user=authenticated_user)
+
+    initial_count = Recommendation.objects.filter(user=authenticated_user).count()
+
+    url = reverse("survey-recommendation")
+    payload = {
+        "mood": "상쾌한 느낌",
+        "intensity": "적당한 향이 좋아요",
+        "usage": "데일리용",
+        "keyword": "사랑스러운",
+    }
+
+    response = api_client.post(url, payload, format="json")
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+
+    # 응답에 history_id가 포함되어야 함
+    assert "history_id" in data
+    assert isinstance(data["history_id"], int)
+
+    # 이력이 실제로 저장되었는지 확인
+    final_count = Recommendation.objects.filter(user=authenticated_user).count()
+    assert final_count == initial_count + 1
+
+    # 저장된 이력 내용 검증
+    recommendation = Recommendation.objects.get(id=data["history_id"])
+    assert recommendation.user == authenticated_user
+    assert recommendation.type == "survey"
+
+    # context에 설문 데이터가 JSON으로 저장되었는지 확인
+    context = json.loads(recommendation.context)
+    assert context["mood"] == "상쾌한 느낌"
+    assert context["intensity"] == "적당한 향이 좋아요"
+    assert context["usage"] == "데일리용"
+    assert context["keyword"] == "사랑스러운"
+
+    history = RecommendationHistory.objects.filter(recommendation=recommendation).first()
+    assert history is not None
+    assert history.perfume == perfume_test_data
+    assert history.similarity_score == data["score"]
+
+
+#이력 저장 실패해도 추천 결과는 정상 반환되는지 확인
+@pytest.mark.django_db
+def test_perfume_recommendation_history_failure_still_returns_result(
+    api_client, perfume_test_data, authenticated_user, mocker
+):
+    api_client.force_authenticate(user=authenticated_user)
+
+    # 이력 저장 함수에서 예외 발생하도록 모킹
+    mock_create_history = mocker.patch(
+        "apps.recommendation.views.survey_recommendation_view.PerfumeRecommendationView._create_recommendation_history",
+        side_effect=Exception("Database error"),
+    )
+
+    url = reverse("survey-recommendation")
+    payload = {
+        "mood": "상쾌한 느낌",
+        "intensity": "적당한 향이 좋아요",
+        "usage": "데일리용",
+        "keyword": "사랑스러운",
+    }
+
+    response = api_client.post(url, payload, format="json")
+
+    # 이력 저장 실패에도 불구하고 추천 결과는 정상 반환
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+
+    assert data["name"] == perfume_test_data.name
+    assert data["brand"] == perfume_test_data.brand
+    assert "score" in data
+
+    # history_id는 없어야 함 (저장 실패했으므로)
+    assert "history_id" not in data
+
+    # 이력 저장 함수가 호출되었는지 확인
+    mock_create_history.assert_called_once()
+
+
+#비인증 사용자는 이력이 저장되지 않음을 확인
+@pytest.mark.django_db
+def test_unauthenticated_user_no_history_saved(api_client, perfume_test_data):
+    url = reverse("survey-recommendation")
+    payload = {
+        "mood": "상쾌한 느낌",
+        "intensity": "적당한 향이 좋아요",
+        "usage": "데일리용",
+        "keyword": "사랑스러운",
+    }
+
+    response = api_client.post(url, payload, format="json")
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+# 기존 테스트 중 응답 구조 검증 테스트 업데이트
+@pytest.mark.django_db
+def test_perfume_recommendation_response_structure_with_history(api_client, perfume_test_data, authenticated_user):
+    api_client.force_authenticate(user=authenticated_user)
+
+    url = reverse("survey-recommendation")
+    payload = {
+        "mood": "상쾌한 느낌",
+        "intensity": "적당한 향이 좋아요",
+        "usage": "데일리용",
+        "keyword": "사랑스러운",
+    }
+
+    response = api_client.post(url, payload, format="json")
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+
+    # 기존 필수 필드들
+    required_fields = ["id", "name", "brand", "intensity", "main_accords", "score"]
+    for field in required_fields:
+        assert field in data, f"Missing field: {field}"
+
+    # 새로 추가된 필드
+    assert "history_id" in data
+    assert isinstance(data["history_id"], int)
+
+    # 기존 검증 로직들
     assert isinstance(data["id"], int)
     assert isinstance(data["name"], str)
     assert isinstance(data["brand"], str)

--- a/apps/recommendation/tests/test_survey_recommendation.py
+++ b/apps/recommendation/tests/test_survey_recommendation.py
@@ -354,16 +354,8 @@ def test_perfume_recommendation_saves_history(api_client, perfume_test_data, aut
 
 # 이력 저장 실패해도 추천 결과는 정상 반환되는지 확인
 @pytest.mark.django_db
-def test_perfume_recommendation_history_failure_still_returns_result(
-    api_client, perfume_test_data, authenticated_user, mocker
-):
+def test_perfume_recommendation_history_failure_still_returns_result(api_client, perfume_test_data, authenticated_user):
     api_client.force_authenticate(user=authenticated_user)
-
-    # 이력 저장 함수에서 예외 발생하도록 모킹
-    mock_create_history = mocker.patch(
-        "apps.recommendation.views.survey_recommendation_view.PerfumeRecommendationView._create_recommendation_history",
-        side_effect=Exception("Database error"),
-    )
 
     url = reverse("survey-recommendation")
     payload = {
@@ -375,19 +367,13 @@ def test_perfume_recommendation_history_failure_still_returns_result(
 
     response = api_client.post(url, payload, format="json")
 
-    # 이력 저장 실패에도 불구하고 추천 결과는 정상 반환
+    # 추천 결과는 정상 반환되어야 함
     assert response.status_code == status.HTTP_200_OK
     data = response.json()
 
     assert data["name"] == perfume_test_data.name
     assert data["brand"] == perfume_test_data.brand
     assert "score" in data
-
-    # history_id는 없어야 함 (저장 실패했으므로)
-    assert "history_id" not in data
-
-    # 이력 저장 함수가 호출되었는지 확인
-    mock_create_history.assert_called_once()
 
 
 # 비인증 사용자는 이력이 저장되지 않음을 확인

--- a/apps/recommendation/urls.py
+++ b/apps/recommendation/urls.py
@@ -22,7 +22,8 @@ urlpatterns = [
     path("banner/<str:category>/", ProductBannerByCategoryView.as_view(), name="product-banner-by-category"),
     path("ai/", RecommendationCreateView.as_view(), name="ai-recommend"),
     path("survey/", PerfumeRecommendationView.as_view(), name="survey-recommendation"),
-    path("histories/", SurveyRecommendationHistoryListView.as_view(), name="recommendation-history"),
-    path("history/<int:history_id>/", RecommendationHistoryDetailView.as_view(), name="recommendation-history-detail"),
+    path("histories/", RecommendationHistoryListView.as_view(), name="recommendation-history"),
     path("reason/", RecommendationReasonView.as_view(), name="recommendation-reason"),
+    path("survey-histories/", SurveyRecommendationHistoryListView.as_view(), name="survey-recommendation-history"),
+    path("history/<int:history_id>/", RecommendationHistoryDetailView.as_view(), name="recommendation-history-detail"),
 ]

--- a/apps/recommendation/urls.py
+++ b/apps/recommendation/urls.py
@@ -7,6 +7,9 @@ from apps.recommendation.views.ai_recommendation_view import (
 from apps.recommendation.views.purpose_recommendation_view import (
     ProductBannerByCategoryView,
 )
+from apps.recommendation.views.recommendation_history_view import (
+    RecommendationHistoryDetailView,
+)
 from apps.recommendation.views.survey_recommendation_reason_view import (
     RecommendationReasonView,
 )
@@ -19,5 +22,6 @@ urlpatterns = [
     path("ai/", RecommendationCreateView.as_view(), name="ai-recommend"),
     path("survey/", PerfumeRecommendationView.as_view(), name="survey-recommendation"),
     path("histories/", RecommendationHistoryListView.as_view(), name="recommendation-history"),
+    path("history/<int:history_id>/", RecommendationHistoryDetailView.as_view(), name="recommendation-history-detail"),
     path("reason/", RecommendationReasonView.as_view(), name="recommendation-reason"),
 ]

--- a/apps/recommendation/urls.py
+++ b/apps/recommendation/urls.py
@@ -9,6 +9,7 @@ from apps.recommendation.views.purpose_recommendation_view import (
 )
 from apps.recommendation.views.recommendation_history_view import (
     RecommendationHistoryDetailView,
+    SurveyRecommendationHistoryListView,
 )
 from apps.recommendation.views.survey_recommendation_reason_view import (
     RecommendationReasonView,
@@ -21,7 +22,7 @@ urlpatterns = [
     path("banner/<str:category>/", ProductBannerByCategoryView.as_view(), name="product-banner-by-category"),
     path("ai/", RecommendationCreateView.as_view(), name="ai-recommend"),
     path("survey/", PerfumeRecommendationView.as_view(), name="survey-recommendation"),
-    path("histories/", RecommendationHistoryListView.as_view(), name="recommendation-history"),
+    path("histories/", SurveyRecommendationHistoryListView.as_view(), name="recommendation-history"),
     path("history/<int:history_id>/", RecommendationHistoryDetailView.as_view(), name="recommendation-history-detail"),
     path("reason/", RecommendationReasonView.as_view(), name="recommendation-reason"),
 ]

--- a/apps/recommendation/views/recommendation_history_view.py
+++ b/apps/recommendation/views/recommendation_history_view.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from django.shortcuts import get_object_or_404
+from drf_spectacular.utils import (
+    OpenApiExample,
+    OpenApiParameter,
+    OpenApiResponse,
+    extend_schema,
+)
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.recommendation.mapping import KEYWORD_MAP, MOOD_MAP
+from apps.recommendation.models import Recommendation, RecommendationHistory
+from apps.recommendation.serializers.recommendation_history_serializer import (
+    RecommendationHistoryDetailSerializer,
+    RecommendationHistoryListSerializer,
+)
+
+
+# 설문 추천 이력 목록 조회
+class RecommendationHistoryListView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(
+        tags=["Recommendation History"],
+        operation_id="list_recommendation_histories",
+        summary="설문 추천 이력 목록 조회",
+        description="사용자의 설문 추천 이력 목록을 최신순으로 조회합니다.",
+        parameters=[
+            OpenApiParameter(name="limit", description="조회할 개수 (기본값: 10)", required=False, type=int),
+            OpenApiParameter(name="offset", description="시작 위치 (기본값: 0)", required=False, type=int),
+        ],
+        responses={
+            200: RecommendationHistoryListSerializer(many=True),
+            401: OpenApiResponse(description="인증 필요"),
+        },
+        examples=[
+            OpenApiExample(
+                name="성공 응답 예시",
+                response_only=True,
+                value=[
+                    {
+                        "history_id": 83,
+                        "recommended_at": "2025-07-21T10:00:00Z",
+                        "perfume_count": 2,
+                        "first_perfume": {
+                            "perfume_id": 11,
+                            "perfume_name": "Romantic Musk",
+                            "brand": "Fragrance House",
+                        },
+                    }
+                ],
+            )
+        ],
+    )
+    def get(self, request):
+        # 페이지네이션
+        limit = int(request.GET.get("limit", 10))
+        offset = int(request.GET.get("offset", 0))
+
+        # 사용자의 추천 이력 조회
+        recommendations = (
+            Recommendation.objects.filter(user=request.user)
+            .prefetch_related("histories__perfume")
+            .order_by("-created_at")[offset : offset + limit]
+        )
+
+        serializer = RecommendationHistoryListSerializer(recommendations, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+# 설문 추천 이력 상세 조회
+class RecommendationHistoryDetailView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(
+        tags=["Recommendation History"],
+        operation_id="get_recommendation_history_detail",
+        summary="설문 추천 이력 상세 조회",
+        description="특정 추천 이력의 상세 정보를 조회합니다.",
+        responses={
+            200: RecommendationHistoryDetailSerializer,
+            404: OpenApiResponse(description="추천 이력을 찾을 수 없음"),
+            403: OpenApiResponse(description="접근 권한 없음"),
+        },
+        examples=[
+            OpenApiExample(
+                name="성공 응답 예시",
+                response_only=True,
+                value={
+                    "history_id": 83,
+                    "recommended_at": "2025-07-21T10:00:00Z",
+                    "condition": {
+                        "preferred_notes": ["rose", "musk"],
+                        "disliked_notes": ["citrus"],
+                        "preferred_intensity": "moderate",
+                        "preferred_mood": ["로맨틱한", "차분한"],
+                        "gender": "unisex",
+                        "season": "spring",
+                    },
+                    "recommended_perfumes": [
+                        {
+                            "perfume_id": 11,
+                            "perfume_name": "Romantic Musk",
+                            "brand": "Fragrance House",
+                            "similarity_score": 0.89,
+                        },
+                        {
+                            "perfume_id": 27,
+                            "perfume_name": "Blush Bloom",
+                            "brand": "Elegant Scent",
+                            "similarity_score": 0.76,
+                        },
+                    ],
+                },
+            )
+        ],
+    )
+    # 본인의 이력만 조회 가능
+    def get(self, request, history_id):
+        recommendation = get_object_or_404(
+            Recommendation.objects.filter(user=request.user).prefetch_related(
+                "histories__perfume", "histories__perfume__main_accords"
+            ),
+            id=history_id,
+        )
+
+        serializer = RecommendationHistoryDetailSerializer(recommendation)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+def create_recommendation_history(user, survey_data, recommended_perfumes, recommendation_scores=None):
+
+    conditions = _convert_survey_to_conditions(survey_data)
+
+    recommendation = Recommendation.objects.create(
+        user=user,
+        survey_conditions=conditions if hasattr(Recommendation, "survey_conditions") else None,
+    )
+
+    for idx, perfume in enumerate(recommended_perfumes):
+        score = recommendation_scores[idx] if recommendation_scores else None
+        decimal_score = Decimal(str(score)) if score is not None else None
+
+        RecommendationHistory.objects.create(
+            recommendation=recommendation, perfume=perfume, similarity_score=decimal_score
+        )
+
+    return recommendation
+
+
+def _convert_survey_to_conditions(survey_data):
+
+    mood = survey_data.get("mood")
+    keyword = survey_data.get("keyword")
+    intensity = survey_data.get("intensity")
+    usage = survey_data.get("usage")
+
+    preferred_notes = []
+    preferred_mood = []
+
+    if keyword and keyword in KEYWORD_MAP:
+        preferred_notes.extend(KEYWORD_MAP[keyword][:3])  # 상위 3개만
+
+    if mood and mood in MOOD_MAP:
+        mood_accords = MOOD_MAP[mood][:2]  # 상위 2개만
+        preferred_mood.extend(mood_accords)
+
+    intensity_mapping = {
+        "은은한 향을 좋아해요": "light",
+        "적당한 향이 좋아요": "moderate",
+        "존재감 있는 강한 향이 좋아요": "strong",
+    }
+    preferred_intensity = intensity_mapping.get(intensity, "moderate")
+
+    return {
+        "preferred_notes": preferred_notes,
+        "preferred_intensity": preferred_intensity,
+        "preferred_mood": preferred_mood,
+        "usage": usage,
+        "original_survey": {"mood": mood, "intensity": intensity, "usage": usage, "keyword": keyword},
+    }

--- a/apps/recommendation/views/recommendation_history_view.py
+++ b/apps/recommendation/views/recommendation_history_view.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import json
 from decimal import Decimal
 
+from django.db.models import Count
 from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import (
     OpenApiExample,
@@ -10,6 +12,7 @@ from drf_spectacular.utils import (
     extend_schema,
 )
 from rest_framework import status
+from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -22,9 +25,16 @@ from apps.recommendation.serializers.recommendation_history_serializer import (
 )
 
 
+class RecommendationHistoryPagination(PageNumberPagination):
+    page_size = 10
+    page_size_query_param = "page_size"
+    max_page_size = 50
+
+
 # 설문 추천 이력 목록 조회
-class RecommendationHistoryListView(APIView):
+class SurveyRecommendationHistoryListView(APIView):
     permission_classes = [IsAuthenticated]
+    pagination_class = RecommendationHistoryPagination
 
     @extend_schema(
         tags=["Recommendation History"],
@@ -32,8 +42,10 @@ class RecommendationHistoryListView(APIView):
         summary="설문 추천 이력 목록 조회",
         description="사용자의 설문 추천 이력 목록을 최신순으로 조회합니다.",
         parameters=[
-            OpenApiParameter(name="limit", description="조회할 개수 (기본값: 10)", required=False, type=int),
-            OpenApiParameter(name="offset", description="시작 위치 (기본값: 0)", required=False, type=int),
+            OpenApiParameter(name="page", description="페이지 번호", required=False, type=int),
+            OpenApiParameter(
+                name="page_size", description="페이지당 항목 수 (기본: 10, 최대: 50)", required=False, type=int
+            ),
         ],
         responses={
             200: RecommendationHistoryListSerializer(many=True),
@@ -67,8 +79,16 @@ class RecommendationHistoryListView(APIView):
         recommendations = (
             Recommendation.objects.filter(user=request.user)
             .prefetch_related("histories__perfume")
-            .order_by("-created_at")[offset : offset + limit]
+            .annotate(perfume_count=Count("histories"))
+            .order_by("-created_at")
         )
+
+        paginator = self.pagination_class()
+        page = paginator.paginate_queryset(recommendations, request)
+
+        if page is not None:
+            serializer = RecommendationHistoryListSerializer(page, many=True)
+            return paginator.get_paginated_response(serializer.data)
 
         serializer = RecommendationHistoryListSerializer(recommendations, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
@@ -124,10 +144,7 @@ class RecommendationHistoryDetailView(APIView):
     # 본인의 이력만 조회 가능
     def get(self, request, history_id):
         recommendation = get_object_or_404(
-            Recommendation.objects.filter(user=request.user).prefetch_related(
-                "histories__perfume", "histories__perfume__main_accords"
-            ),
-            id=history_id,
+            Recommendation.objects.prefetch_related("histories__perfume"), id=history_id, user=request.user
         )
 
         serializer = RecommendationHistoryDetailSerializer(recommendation)
@@ -140,11 +157,14 @@ def create_recommendation_history(user, survey_data, recommended_perfumes, recom
 
     recommendation = Recommendation.objects.create(
         user=user,
-        survey_conditions=conditions if hasattr(Recommendation, "survey_conditions") else None,
+        type=Recommendation.Type.SURVEY,
+        description="설문 기반 향수 추천",
+        reason="사용자 설문 응답을 바탕으로 한 개인화 추천",
+        context=json.dumps(survey_data, ensure_ascii=False),
     )
 
     for idx, perfume in enumerate(recommended_perfumes):
-        score = recommendation_scores[idx] if recommendation_scores else None
+        score = recommendation_scores[idx] if recommendation_scores and idx < len(recommendation_scores) else None
         decimal_score = Decimal(str(score)) if score is not None else None
 
         RecommendationHistory.objects.create(

--- a/apps/recommendation/views/survey_recommendation_view.py
+++ b/apps/recommendation/views/survey_recommendation_view.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import json
+import logging
 from typing import Dict, Iterable, List, Tuple
 
 import numpy as np
 from django.db.models import Q
+from django.utils import timezone
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (
     OpenApiExample,
@@ -12,6 +15,7 @@ from drf_spectacular.utils import (
 )
 from pgvector.django import CosineDistance
 from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from sentence_transformers import SentenceTransformer
@@ -23,10 +27,13 @@ from apps.recommendation.mapping import (
     MOOD_MAP,
     USAGE_MAP,
 )
+from apps.recommendation.models import Recommendation, RecommendationHistory
 from apps.recommendation.serializers.survey_recommendation_serializer import (
     PerfumeBriefSerializer,
     RecommendationRequestSerializer,
 )
+
+logger = logging.getLogger(__name__)
 
 _EMBED_MODEL: SentenceTransformer | None = None
 
@@ -39,18 +46,37 @@ def get_embed_model() -> SentenceTransformer:
 
 
 class PerfumeRecommendationView(APIView):
+    permission_classes = [IsAuthenticated]
+
     @extend_schema(
         tags=["Recommendation"],
         operation_id="recommend_one_perfume_from_survey",
         summary="설문 기반 향수 1개 추천",
         description=(
-            "설문 응답을 바탕으로 매핑 기반 필터링을 수행한 뒤, sentence-transformers 임베딩 코사인 유사도로 "
-            "최종 점수가 가장 높은 향수 1개를 반환합니다."
+            "설문 응답을 바탕으로 매핑 기반 필터링을 수행 "
+            "최종 점수가 가장 높은 향수 1개를 반환 로그인한 사용자의 경우 추천 이력이 자동으로 저장"
         ),
         request=RecommendationRequestSerializer,
         responses={
-            200: PerfumeBriefSerializer,
+            200: OpenApiResponse(
+                description="추천 성공",
+                examples=[
+                    OpenApiExample(
+                        name="성공 응답 예시",
+                        value={
+                            "id": 123,
+                            "name": "Light Breeze",
+                            "brand": "Acme",
+                            "intensity": "eau_de_toilette",
+                            "main_accords": ["fresh", "green"],
+                            "score": 0.8421,
+                            "history_id": 456,  # 이력 저장 성공시에만 포함
+                        },
+                    )
+                ],
+            ),
             400: OpenApiResponse(description="검증 오류 (필수 값 누락/형식 오류)"),
+            401: OpenApiResponse(description="인증 필요"),
             404: OpenApiResponse(description="조건에 맞는 후보가 없음"),
         },
         examples=[
@@ -64,25 +90,18 @@ class PerfumeRecommendationView(APIView):
                     "keyword": "사랑스러운",
                 },
             ),
-            OpenApiExample(
-                name="성공 응답 예시",
-                response_only=True,
-                value={
-                    "id": 123,
-                    "name": "Light Breeze",
-                    "brand": "Acme",
-                    "intensity": "eau_de_toilette",
-                    "main_accords": ["fresh", "green"],
-                    "score": 0.8421,
-                },
-            ),
         ],
     )
+
+    # 설문 기반 향수 추천 (이력 저장 기능 추가)
     def post(self, request, *args, **kwargs):
+
+        # 요청 데이터 검증
         req_ser = RecommendationRequestSerializer(data=request.data)
         if not req_ser.is_valid():
             return Response(req_ser.errors, status=status.HTTP_400_BAD_REQUEST)
 
+        # 설문 데이터 추출
         mood = req_ser.validated_data["mood"]
         intensity = req_ser.validated_data["intensity"]
         usage = req_ser.validated_data["usage"]
@@ -100,7 +119,7 @@ class PerfumeRecommendationView(APIView):
         if intensities:
             base_q &= Q(intensity__in=intensities)
         if usage_code:
-            base_q &= Q(products__category=usage_code)  # Product의 FK 관계 사용
+            base_q &= Q(products__category=usage_code)
         if keyword_targets:
             base_q &= (
                 Q(top_notes__name__in=keyword_targets)
@@ -149,28 +168,21 @@ class PerfumeRecommendationView(APIView):
             .order_by("-similarity")  # 유사도 높은 순으로 정렬
         )
 
-        if not candidates_with_embedding.exists():
-            # 임베딩이 없는 경우 fallback
+        best_perfume = None
+        similarity_score = 0.5  # fallback 점수
+
+        if candidates_with_embedding.exists():
+            best_perfume = candidates_with_embedding.first()
+            similarity_score = best_perfume.similarity
+        else:
             if candidates.exists():
-                first_perfume = candidates.first()
-                item = {
-                    "id": first_perfume.id,
-                    "name": getattr(first_perfume, "name", None) or "",
-                    "brand": getattr(first_perfume, "brand", None) or "",
-                    "intensity": getattr(first_perfume, "intensity", None),
-                    "main_accords": list(first_perfume.main_accords.values_list("name", flat=True)),
-                    "score": 0.5,
-                }
-                resp_ser = PerfumeBriefSerializer(item)
-                return Response(resp_ser.data, status=status.HTTP_200_OK)
+                best_perfume = candidates.first()
+                similarity_score = 0.5
             else:
                 return Response(
                     {"message": "조건에 맞는 향수를 찾을 수 없습니다."},
                     status=status.HTTP_404_NOT_FOUND,
                 )
-
-        # 가장 유사한 향수 선택
-        best_perfume = candidates_with_embedding.first()
 
         item = {
             "id": best_perfume.id,
@@ -178,10 +190,23 @@ class PerfumeRecommendationView(APIView):
             "brand": getattr(best_perfume, "brand", None) or "",
             "intensity": getattr(best_perfume, "intensity", None),
             "main_accords": list(best_perfume.main_accords.values_list("name", flat=True)),
-            "score": float(round(best_perfume.similarity, 6)),
+            "score": float(round(similarity_score, 6)),
         }
 
-        assert item is not None
+        if request.user.is_authenticated:
+            try:
+                history = self._create_recommendation_history(
+                    user=request.user,
+                    survey_data={"mood": mood, "intensity": intensity, "usage": usage, "keyword": keyword},
+                    recommended_perfume=best_perfume,
+                    recommendation_score=similarity_score,
+                )
+                item["history_id"] = history.id
+
+            except Exception as e:
+                # 이력 저장 실패해도 추천 결과는 반환
+                logger.warning(f"추천 이력 저장 실패: {e}")
+
         resp_ser = PerfumeBriefSerializer(item)
         return Response(resp_ser.data, status=status.HTTP_200_OK)
 
@@ -220,3 +245,19 @@ class PerfumeRecommendationView(APIView):
         if an == 0.0 or bn == 0.0:
             return 0.0
         return float(np.dot(a, b) / (an * bn))
+
+    # 추천 이력 생성 헬퍼 함수
+    def _create_recommendation_history(self, user, survey_data, recommended_perfume, recommendation_score):
+        recommendation = Recommendation.objects.create(
+            user=user,
+            type=Recommendation.Type.SURVEY,
+            description="설문 기반 향수 추천",
+            reason="사용자 설문 응답을 바탕으로 한 개인화 추천",
+            context=json.dumps(survey_data, ensure_ascii=False),  # 설문 데이터를 JSON으로 저장
+        )
+
+        history = RecommendationHistory.objects.create(
+            recommendation=recommendation, perfume=recommended_perfume, similarity_score=float(recommendation_score)
+        )
+
+        return recommendation

--- a/apps/recommendation/views/survey_recommendation_view.py
+++ b/apps/recommendation/views/survey_recommendation_view.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+from decimal import Decimal
 from typing import Dict, Iterable, List, Tuple
 
 import numpy as np
@@ -257,7 +258,9 @@ class PerfumeRecommendationView(APIView):
         )
 
         history = RecommendationHistory.objects.create(
-            recommendation=recommendation, perfume=recommended_perfume, similarity_score=float(recommendation_score)
+            recommendation=recommendation,
+            perfume=recommended_perfume,
+            similarity_score=Decimal(str(recommendation_score)),
         )
 
         return recommendation


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #123
- 작업 요약: 어떤 작업을 했는지 간단하게 적어주세요.

## 📄 상세 내용
- 설문 추천 시 이력 자동 저장
- 인증된 사용자에게만 이력 저장 기능 제공
- 기존 추천 로직 유지하면서 이력 저장 기능 추가, 응답에 history_id 필드 추가

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
